### PR TITLE
Upgrade to Go 1.26 and fix IP-change detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+A single-binary Go service that polls the machine's public IP and updates OVH
+Dynamic DNS (DynDNS) records when it changes. Distributed as a multi-arch Docker
+image (`sazap10/ovh-ip-updater-go`).
+
+## Commands
+
+```bash
+go build                    # build the ovh-ip-updater-go binary
+go test ./...               # run all tests
+go test -run TestGetIPAddress_Success   # run a single test by name
+golangci-lint run           # lint (config in .golangci.yml)
+docker compose up -d        # run the service via the prebuilt image
+docker compose run lint     # run golangci-lint inside the CI Docker target
+```
+
+Toolchain versions are pinned in `.tool-versions` (managed by asdf): Go 1.26.4,
+golangci-lint 2.12.2. Note `go.mod` declares `go 1.23` as the minimum language
+version — keep it at or below the installed toolchain.
+
+## Configuration
+
+All runtime config comes from environment variables (loaded from a `.env` file
+in the working dir if present, via `godotenv`):
+
+- `OVH_USERNAME`, `OVH_PASSWORD` — OVH DynDNS credentials (required)
+- `DOMAINS` — comma-separated list of hostnames to update (required)
+- `SLEEP_DURATION` — poll interval in seconds (default 3600)
+- `BUGSNAG_API_KEY` — optional; enables Bugsnag error reporting
+
+## Architecture
+
+The entire program is `main.go` (~220 lines); `main_test.go` covers it. Key
+points for making changes:
+
+- **Main loop** (`main`): fetches the public IP from `api.ipify.org`, and only
+  calls the OVH update endpoint for each domain when the IP differs from the
+  previous iteration. Sleeps `SLEEP_DURATION` between cycles. Runs forever.
+- **Retry wrappers**: `getIPAddressWithRetry` / `setDyndnsIPAddressWithRetry`
+  wrap the plain HTTP calls with `cenkalti/backoff/v6` (exponential backoff).
+  Both accept variadic `backoff.RetryOption` — this is the seam tests use to
+  inject `fastBackoff` (constant 1ms backoff + capped tries) so they don't wait
+  on the real schedule.
+- **Testability seam**: the IP and OVH URLs are passed as parameters (defaults
+  in `defaultIPAddressURL` / `defaultOVHUpdateURL`) so tests point them at
+  `httptest` servers. Preserve this pattern — don't hardcode URLs inside the
+  request functions.
+- **Error reporting** (`notify`): sends to Bugsnag if `BUGSNAG_API_KEY` is set,
+  otherwise logs. Errors are wrapped with `pkg/errors`.
+
+When updating the version, change `AppVersion` in the `bugsnag.Configure` call.
+
+## Docker & CI
+
+- `Dockerfile` is multi-stage: `builder` (compiles), `ci` (adds golangci-lint),
+  and the final `alpine` image which runs `script/run.sh`. `run.sh` traps
+  SIGTERM/SIGINT to forward shutdown to the app and waits ~1s on exit so Bugsnag
+  can flush its notifier.
+- `.github/workflows/ci.yml` runs on every push: lints via asdf, then builds and
+  pushes per-platform images (amd64, arm/v7, arm/v8, arm64) to Docker Hub and
+  assembles a multi-arch manifest. Version tags (`vX.Y.Z`) also get `latest`;
+  `master` pushes as `latest`. Tagged builds report a release to Bugsnag.
+
+## Conventions
+
+Commits follow Conventional Commits. Dependencies are kept current by Renovate.

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,10 @@ FROM golang:1.26 AS ci
 # Ensure we run all go commands against the vendor folder
 ENV GOFLAGS=-tags=ci
 
-# Install linter
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.63.3
+# Install linter (keep this version in sync with .tool-versions).
+# The install script is pinned to the matching release tag: the master script's
+# asset matching incorrectly picks up the .tar.gz.sbom.json file for v2 releases.
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.12.2/install.sh | sh -s -- -b /usr/local/bin v2.12.2
 
 WORKDIR /build
 

--- a/go.mod
+++ b/go.mod
@@ -1,16 +1,16 @@
 module github.com/sazap10/ovh-ip-updater-go
 
-go 1.23
+go 1.26
 
 require (
 	github.com/bugsnag/bugsnag-go/v2 v2.6.4
 	github.com/cenkalti/backoff/v6 v6.0.1
 	github.com/joho/godotenv v1.5.1
-	github.com/pkg/errors v0.9.1
 )
 
 require (
 	github.com/bugsnag/panicwrap v1.3.4 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 )

--- a/main.go
+++ b/main.go
@@ -7,14 +7,15 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/bugsnag/bugsnag-go/v2"
 	"github.com/cenkalti/backoff/v6"
 	"github.com/joho/godotenv"
-	"github.com/pkg/errors"
 )
 
 // Default endpoints. The retry helpers take the URL as a parameter so tests can
@@ -32,7 +33,6 @@ type dynDNSRequest struct {
 }
 
 func main() {
-	ctx := context.Background()
 	err := godotenv.Load()
 	if err != nil {
 		log.Println(".env not provided, using environment variables instead")
@@ -62,40 +62,57 @@ func main() {
 
 	sleepDuration := envInt("SLEEP_DURATION", 3600)
 
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
 	client := &http.Client{
 		Timeout: time.Second * 30,
 	}
 
-	ipAddress := ""
+	ticker := time.NewTicker(time.Duration(sleepDuration) * time.Second)
+	defer ticker.Stop()
+
 	var prevIPAddress string
 
 	for {
-		prevIPAddress = ipAddress
+		prevIPAddress = updateDomains(ctx, client, domains, username, password, prevIPAddress)
 
-		ipAddress, err := getIPAddressWithRetry(ctx, client, defaultIPAddressURL)
-		switch {
-		case err != nil:
-			notify(err)
-		case prevIPAddress != ipAddress:
-			for _, domainName := range domains {
-				log.Printf("Settings domain: %s to ip: %s\n", domainName, ipAddress)
-				requestArgs := dynDNSRequest{
-					ipAddress:  ipAddress,
-					domainName: domainName,
-					username:   username,
-					password:   password,
-				}
-				err = setDyndnsIPAddressWithRetry(ctx, client, defaultOVHUpdateURL, requestArgs)
-				if err != nil {
-					notify(err)
-				}
-			}
-		default:
-			log.Println("IP address is the same, skipping OVH set")
+		select {
+		case <-ctx.Done():
+			log.Println("Shutting down")
+			return
+		case <-ticker.C:
 		}
-
-		time.Sleep(time.Duration(sleepDuration) * time.Second)
 	}
+}
+
+// updateDomains fetches the current public IP and, if it has changed since
+// prevIPAddress, pushes it to each domain's OVH DynDNS record. It returns the IP
+// to use as the previous value on the next cycle.
+func updateDomains(ctx context.Context, client *http.Client, domains []string, username, password, prevIPAddress string) string {
+	ipAddress, err := getIPAddressWithRetry(ctx, client, defaultIPAddressURL)
+	switch {
+	case err != nil:
+		notify(err)
+		return prevIPAddress
+	case prevIPAddress != ipAddress:
+		for _, domainName := range domains {
+			log.Printf("Settings domain: %s to ip: %s\n", domainName, ipAddress)
+			requestArgs := dynDNSRequest{
+				ipAddress:  ipAddress,
+				domainName: domainName,
+				username:   username,
+				password:   password,
+			}
+			if err := setDyndnsIPAddressWithRetry(ctx, client, defaultOVHUpdateURL, requestArgs); err != nil {
+				notify(err)
+			}
+		}
+	default:
+		log.Println("IP address is the same, skipping OVH set")
+	}
+
+	return ipAddress
 }
 
 func getIPAddressWithRetry(ctx context.Context, client *http.Client, url string, opts ...backoff.RetryOption) (string, error) {
@@ -111,19 +128,19 @@ func getIPAddressWithRetry(ctx context.Context, client *http.Client, url string,
 	}, opts...)
 	ip, err := backoff.Retry(ctx, operation, retryOpts...)
 	if err != nil {
-		return "", errors.Wrapf(err, "Unable to get IP address, retries exhausted")
+		return "", fmt.Errorf("Unable to get IP address, retries exhausted: %w", err)
 	}
 	return ip, nil
 }
 
 func getIPAddress(ctx context.Context, client *http.Client, url string) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return "", errors.Wrap(err, "Unable to create request to api.ipify.org")
+		return "", fmt.Errorf("Unable to create request to api.ipify.org: %w", err)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", errors.Wrap(err, "Unable to get IP address")
+		return "", fmt.Errorf("Unable to get IP address: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -133,7 +150,7 @@ func getIPAddress(ctx context.Context, client *http.Client, url string) (string,
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", errors.Wrap(err, "Unable to read api.ipify.org body")
+		return "", fmt.Errorf("Unable to read api.ipify.org body: %w", err)
 	}
 	return string(body), nil
 }
@@ -152,7 +169,7 @@ func setDyndnsIPAddressWithRetry(ctx context.Context, client *http.Client, baseU
 	}, opts...)
 	result, err := backoff.Retry(ctx, operation, retryOpts...)
 	if err != nil {
-		return errors.Wrapf(err, "Unable to set dyndns ip for domain %s, retries exhausted", r.domainName)
+		return fmt.Errorf("Unable to set dyndns ip for domain %s, retries exhausted: %w", r.domainName, err)
 	}
 	log.Printf("Set dyndns ip for domain %s: %s\n", r.domainName, result)
 	return nil
@@ -160,15 +177,15 @@ func setDyndnsIPAddressWithRetry(ctx context.Context, client *http.Client, baseU
 
 func setDyndnsIPAddress(ctx context.Context, client *http.Client, baseURL string, r dynDNSRequest) (string, error) {
 	url := fmt.Sprintf("%s?system=dyndns&hostname=%s&myip=%s", baseURL, r.domainName, r.ipAddress)
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return "", errors.Wrapf(err, "Unable to create request to set IP Address for domain: %s", r.domainName)
+		return "", fmt.Errorf("Unable to create request to set IP Address for domain %s: %w", r.domainName, err)
 	}
 	req.SetBasicAuth(r.username, r.password)
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", errors.Wrapf(err, "Unable to set IP Address for domain: %s", r.domainName)
+		return "", fmt.Errorf("Unable to set IP Address for domain %s: %w", r.domainName, err)
 	}
 	defer resp.Body.Close()
 
@@ -178,7 +195,7 @@ func setDyndnsIPAddress(ctx context.Context, client *http.Client, baseURL string
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", errors.Wrapf(err, "Unable to read response body for domain: %s", r.domainName)
+		return "", fmt.Errorf("Unable to read response body for domain %s: %w", r.domainName, err)
 	}
 	return string(body), nil
 }


### PR DESCRIPTION
## Summary

Resolves the Go version mismatch across the repo and ships several correctness/robustness improvements found while investigating.

### Version fixes
- **`go.mod`**: `go 1.23` → `go 1.26`, matching the toolchain, `.tool-versions`, and the Dockerfile.
- **Dockerfile (`ci` stage)**: golangci-lint `v1.63.3` → `2.12.2`. v1.x cannot parse the `version: "2"` `.golangci.yml`, so `docker compose run lint` was broken. The install script is now pinned to the matching release tag — the `master` script's asset matching incorrectly grabs the `.tar.gz.sbom.json` artifact for v2 releases, failing the checksum.

### Fixes & improvements
- **IP-change bug**: the IP fetch in the main loop used `:=`, shadowing the outer `ipAddress`. `prevIPAddress` stayed `""` forever, so OVH was updated *every cycle* regardless of whether the IP changed. The per-cycle logic now lives in `updateDomains`, which returns the fetched IP for the next comparison — restoring the skip-when-unchanged optimization.
- **Graceful shutdown**: `signal.NotifyContext` on SIGINT/SIGTERM cancels the context (aborting in-flight retries) and exits the ticker loop cleanly instead of being hard-killed.
- **Dropped `github.com/pkg/errors`**: replaced with stdlib `fmt.Errorf` `%w` wrapping. `errors.Is`/`As` behaviour is preserved (the existing tests rely on it). It remains an indirect dep via bugsnag, which is expected.

## Verification
- `go build`, `go vet`, `go test ./...` — pass (existing retry/error/context tests unchanged).
- `golangci-lint run` (2.12.2) — 0 issues.
- `docker compose build lint && docker compose run lint` — builds and lints clean, confirming the previously-broken target works.
- `docker compose build ovh-ip-updater-go` — image builds.